### PR TITLE
Version 0.8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+
+[*]
+
+# Microsoft .NET properties
+csharp_indent_braces = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_else = false
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = accessors,events,indexers,properties
+csharp_preferred_modifier_order = private, protected, public, virtual, volatile, abstract, internal, override, sealed, new, static, extern, unsafe, readonly, async:suggestion
+csharp_preserve_single_line_blocks = true
+
+# ReSharper properties
+resharper_align_multiline_parameter = true
+resharper_arguments_literal = positional
+resharper_blank_lines_around_auto_property = 0
+resharper_braces_for_for = required
+resharper_csharp_align_multiline_binary_expressions_chain = true
+resharper_csharp_blank_lines_around_invocable = 0
+resharper_csharp_insert_final_newline = false
+resharper_csharp_max_line_length = 286
+resharper_csharp_wrap_parameters_style = chop_if_long
+resharper_instance_members_qualify_declared_in = 
+resharper_keep_existing_embedded_block_arrangement = false
+resharper_keep_existing_enum_arrangement = false
+resharper_place_expr_property_on_single_line = true
+resharper_remove_blank_lines_near_braces_in_declarations = false
+resharper_space_within_single_line_array_initializer_braces = false
+resharper_wrap_before_declaration_rpar = false
+resharper_wrap_object_and_collection_initializer_style = wrap_if_long

--- a/BrokenNodeDetector/BndResultHighlightManager.cs
+++ b/BrokenNodeDetector/BndResultHighlightManager.cs
@@ -99,8 +99,10 @@ namespace BrokenNodeDetector {
             Vector3 hit;
             bool found = false;
             if (input.m_ignoreBuildingFlags != Building.Flags.All && 
-                Singleton<BuildingManager>.instance.RayCast(ray, input.m_buildingService.m_service, input.m_buildingService.m_subService, input.m_buildingService.m_itemLayers, input.m_ignoreBuildingFlags, out hit, out output.m_building))
-            {
+                Singleton<BuildingManager>.instance.RayCast(ray, input.m_buildingService.m_service, input.m_buildingService.m_subService, input.m_buildingService.m_itemLayers, input.m_ignoreBuildingFlags, out hit, out ushort buildingId)) {
+
+                ushort parentBuilding = Building.FindParentBuilding(buildingId);
+                output.m_building = parentBuilding != 0 ? parentBuilding : buildingId;
                 float distance = Vector3.Distance(hit, origin);
                 if (distance < (double) len)
                 {

--- a/BrokenNodeDetector/BndResultHighlightManager.cs
+++ b/BrokenNodeDetector/BndResultHighlightManager.cs
@@ -22,6 +22,7 @@ namespace BrokenNodeDetector {
         private Dictionary<HighlightType, IHighlightable> _highlightables = new Dictionary<HighlightType, IHighlightable>();
         protected override void Awake() {
             base.Awake();
+            name = "BND_ResultHighlightManager";
             _mainCamera = Camera.main;
             _highlightables = new Dictionary<HighlightType, IHighlightable> {
                 {HighlightType.Building, new BuildingHighlight()},

--- a/BrokenNodeDetector/BrokenNodeDetector.cs
+++ b/BrokenNodeDetector/BrokenNodeDetector.cs
@@ -16,6 +16,7 @@ namespace BrokenNodeDetector
         private MainUI _testUI;
 #endif
 
+        [UsedImplicitly]
         public void OnEnabled() {
             Debug.Log($"[BND] Broken Node Detector enabled. Version {Version}");
             HarmonyHelper.EnsureHarmonyInstalled();
@@ -34,6 +35,7 @@ namespace BrokenNodeDetector
 #endif
         }
 
+        [UsedImplicitly]
         public void OnDisabled() {
             Debug.Log("[BND] Broken Node Detector disabled.");
             if (LoadingExtension.MainUi) {

--- a/BrokenNodeDetector/BrokenNodeDetector.cs
+++ b/BrokenNodeDetector/BrokenNodeDetector.cs
@@ -2,16 +2,17 @@
 using BrokenNodeDetector.UI;
 using CitiesHarmony.API;
 using ColossalFramework.UI;
+using JetBrains.Annotations;
 using UnityEngine;
 
 namespace BrokenNodeDetector
 {
     public class BrokenNodeDetector : IUserMod {
-        public static readonly string Version = "0.7.1";
+        public static readonly string Version = "0.7.2";
 
         public string Name => "Broken Node Detector " + Version;
 
-        public string Description => "Search for broken nodes when TM:PE vehicles despawn.";
+        public string Description => "Search for broken nodes when TM:PE vehicles despawn and more.";
 #if TEST_UI
         private MainUI _testUI;
 #endif

--- a/BrokenNodeDetector/BrokenNodeDetector.cs
+++ b/BrokenNodeDetector/BrokenNodeDetector.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace BrokenNodeDetector
 {
     public class BrokenNodeDetector : IUserMod {
-        public static readonly string Version = "0.7.2";
+        public static readonly string Version = "0.8.0";
 
         public string Name => "Broken Node Detector " + Version;
 

--- a/BrokenNodeDetector/BrokenNodeDetector.csproj
+++ b/BrokenNodeDetector/BrokenNodeDetector.csproj
@@ -70,6 +70,7 @@
     <Compile Include="UI\Tools\BndColorAnimator.cs" />
     <Compile Include="UI\Tools\StuckCimsTool\StuckCims.cs" />
     <Compile Include="UI\Tools\UIHelpers.cs" />
+    <Compile Include="UI\Tools\Utils\EMLUtisl.cs" />
     <Compile Include="UI\Tools\Utils\UnityExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -90,7 +91,7 @@
     <Reference Include="EManagersLib.API">
       <HintPath>..\Dependencies\EManagersLib.API.dll</HintPath>
     </Reference>
-    <Reference Include="ICities, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="ICities, Version=1.15.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\Dependencies\ICities.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/BrokenNodeDetector/BrokenNodeDetector.csproj
+++ b/BrokenNodeDetector/BrokenNodeDetector.csproj
@@ -91,7 +91,7 @@
     <Reference Include="EManagersLib.API">
       <HintPath>..\Dependencies\EManagersLib.API.dll</HintPath>
     </Reference>
-    <Reference Include="ICities, Version=1.15.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="ICities, Version=1.16.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\Dependencies\ICities.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/BrokenNodeDetector/BrokenNodeDetector.csproj
+++ b/BrokenNodeDetector/BrokenNodeDetector.csproj
@@ -88,9 +88,6 @@
     <Reference Include="ColossalManaged, Version=0.3.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\Dependencies\ColossalManaged.dll</HintPath>
     </Reference>
-    <Reference Include="EManagersLib.API">
-      <HintPath>..\Dependencies\EManagersLib.API.dll</HintPath>
-    </Reference>
     <Reference Include="ICities, Version=1.16.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\Dependencies\ICities.dll</HintPath>
     </Reference>
@@ -121,7 +118,6 @@
       del /Q "%25DEPLOYDIR%25*"
       xcopy /y "$(TargetDir)BrokenNodeDetector.dll" "%25DEPLOYDIR%25"
       xcopy /y "$(TargetDir)CitiesHarmony.API.dll" "%25DEPLOYDIR%25"
-      xcopy /y "$(TargetDir)EManagersLib.API.dll" "%25DEPLOYDIR%25"
 
       set DEPLOYDIR=</PostBuildEvent>
   </PropertyGroup>

--- a/BrokenNodeDetector/Properties/AssemblyInfo.cs
+++ b/BrokenNodeDetector/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("BrokenNodeDetector")]
-[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/BrokenNodeDetector/Properties/AssemblyInfo.cs
+++ b/BrokenNodeDetector/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.7.*")]
+[assembly: AssemblyVersion("1.0.8.*")]

--- a/BrokenNodeDetector/UI/MainPanel.cs
+++ b/BrokenNodeDetector/UI/MainPanel.cs
@@ -20,6 +20,7 @@ namespace BrokenNodeDetector.UI {
 
         public override void Awake() {
             base.Awake();
+            name = "BND_MainPanel";
             autoLayout = false;
             width = PANEL_WIDTH;
             height = PANEL_HEIGHT;

--- a/BrokenNodeDetector/UI/MainPanel.cs
+++ b/BrokenNodeDetector/UI/MainPanel.cs
@@ -198,6 +198,8 @@ namespace BrokenNodeDetector.UI {
 
         private void OnResultsClose(bool updateHeight = false) {
             _returnButton.Hide();
+            _preparePanel.CancelPrepare();
+            _preparePanel.Hide();
             RunFadeInOutAnimations(_resultsPanel, _detectorsPanel);
             if (BndResultHighlightManager.instance) {
                 BndResultHighlightManager.instance.enabled = false;

--- a/BrokenNodeDetector/UI/MainUI.cs
+++ b/BrokenNodeDetector/UI/MainUI.cs
@@ -16,6 +16,7 @@ namespace BrokenNodeDetector.UI {
 
         public override void Awake() {
             base.Awake();
+            name = "BND_MainUI";
             var uiView = UIView.GetAView();
             MainPanel = (MainPanel) uiView.AddUIComponent(typeof(MainPanel));
             MainPanel.Initialize();

--- a/BrokenNodeDetector/UI/PreparePanel.cs
+++ b/BrokenNodeDetector/UI/PreparePanel.cs
@@ -48,6 +48,7 @@ namespace BrokenNodeDetector.UI {
         public void CancelPrepare() {
             if (_preparing && _prepareCoroutine != null) {
                 StopCoroutine(_prepareCoroutine);
+                _preparing = false;
             }
         }
         

--- a/BrokenNodeDetector/UI/SettingsUI.cs
+++ b/BrokenNodeDetector/UI/SettingsUI.cs
@@ -1,4 +1,5 @@
 using System;
+using BrokenNodeDetector.UI.Tools.Utils;
 using ColossalFramework;
 using ColossalFramework.UI;
 using EManagersLib.API;
@@ -13,6 +14,7 @@ namespace BrokenNodeDetector.UI {
     public class SettingsUI {
         private const float ROW_WIDTH = 744f - 15f;
         private const float ROW_HEIGHT = 34f;
+        private bool? _emlInstalled;
         
         private SavedInputKey _currentlyEditingBinding;
         
@@ -25,7 +27,12 @@ namespace BrokenNodeDetector.UI {
             UIHelperBase group2 = helper.AddGroup("Other");
             UIPanel panel2 = CreateRowPanel((UIPanel) ((UIHelper) group2).self);
             CreateResetMenuPosition(panel2);
-            CreateLabel(panel2, $"EML integration active: {(PropAPI.m_isEMLInstalled ? "<color #00FF00>Yes</color>" : "No")}", 1f, true);
+            
+            if (!_emlInstalled.HasValue) {
+                _emlInstalled = EmlUtils.IsEmlInstalled();
+            }
+            
+            CreateLabel(panel2, $"EML integration active: {(_emlInstalled.Value ? "<color #00FF00>Yes</color>" : "No")}", 1f, true);
             panel2.autoLayoutDirection = LayoutDirection.Vertical;
             panel2.autoLayoutPadding = new RectOffset(0, 0, 10, 10);
             panel2.autoSize = true;

--- a/BrokenNodeDetector/UI/SettingsUI.cs
+++ b/BrokenNodeDetector/UI/SettingsUI.cs
@@ -1,8 +1,10 @@
 using System;
-using BrokenNodeDetector.UI.Tools.Utils;
 using ColossalFramework;
 using ColossalFramework.UI;
+#if BROKEN_PROPS_SCANNER
+using BrokenNodeDetector.UI.Tools.Utils;
 using EManagersLib.API;
+#endif
 using ICities;
 using UnityEngine;
 
@@ -14,8 +16,10 @@ namespace BrokenNodeDetector.UI {
     public class SettingsUI {
         private const float ROW_WIDTH = 744f - 15f;
         private const float ROW_HEIGHT = 34f;
+#if BROKEN_PROPS_SCANNER
         private bool? _emlInstalled;
-        
+#endif
+      
         private SavedInputKey _currentlyEditingBinding;
         
         public void BuildUI(UIHelper helper) {
@@ -28,11 +32,13 @@ namespace BrokenNodeDetector.UI {
             UIPanel panel2 = CreateRowPanel((UIPanel) ((UIHelper) group2).self);
             CreateResetMenuPosition(panel2);
             
+#if BROKEN_PROPS_SCANNER
             if (!_emlInstalled.HasValue) {
                 _emlInstalled = EmlUtils.IsEmlInstalled();
             }
-            
             CreateLabel(panel2, $"EML integration active: {(_emlInstalled.Value ? "<color #00FF00>Yes</color>" : "No")}", 1f, true);
+#endif
+            
             panel2.autoLayoutDirection = LayoutDirection.Vertical;
             panel2.autoLayoutPadding = new RectOffset(0, 0, 10, 10);
             panel2.autoSize = true;

--- a/BrokenNodeDetector/UI/Tools/BndColorAnimator.cs
+++ b/BrokenNodeDetector/UI/Tools/BndColorAnimator.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 namespace BrokenNodeDetector.UI.Tools {
     public class BndColorAnimator : Singleton<BndColorAnimator> {
         private readonly List<AnimationInfo> _animatorInfos = new List<AnimationInfo>();
+        private readonly NameMatcher _matcher = new NameMatcher();
 
         public static void Animate(Action<Color> target, AnimatedColor color) {
             instance.AnimateInternal(null, target, color, null);
@@ -34,8 +35,8 @@ namespace BrokenNodeDetector.UI.Tools {
         }
 
         private bool InternalIsAnimating(string animationName) {
-            AnimationInfo animationInfo =
-                this._animatorInfos.Find(info => info.AnimationName == animationName);
+            _matcher.name = animationName;
+            AnimationInfo animationInfo = this._animatorInfos.Find(_matcher.Match);
             return animationInfo != null;
         }
 
@@ -43,7 +44,8 @@ namespace BrokenNodeDetector.UI.Tools {
                                      Action<Color> target,
                                      AnimatedColor v,
                                      Action completed) {
-            AnimationInfo animationInfo = _animatorInfos.Find(info => info.AnimationName == animationName);
+            _matcher.name = animationName;
+            AnimationInfo animationInfo = _animatorInfos.Find(_matcher.Match);
             if (animationName != null && animationInfo != null) {
                 animationInfo.Value = v;
                 animationInfo.Completed = completed;
@@ -97,6 +99,7 @@ namespace BrokenNodeDetector.UI.Tools {
         }
 
         private void OnDestroy() {
+            _animatorInfos.Clear();
             GetType().GetField("sInstance", BindingFlags.NonPublic | BindingFlags.Static)
                 ?.SetValue(null, null);
         }
@@ -109,6 +112,13 @@ namespace BrokenNodeDetector.UI.Tools {
             public AnimatedColor Value;
 
             public Action Completed;
+        }
+
+        private class NameMatcher {
+            public string name;
+            public bool Match(AnimationInfo info) {
+                return info.AnimationName == name;
+            }
         }
     }
 }

--- a/BrokenNodeDetector/UI/Tools/BrokenNodesTool/BrokenNodes.cs
+++ b/BrokenNodeDetector/UI/Tools/BrokenNodesTool/BrokenNodes.cs
@@ -62,6 +62,7 @@ namespace BrokenNodeDetector.UI.Tools.BrokenNodesTool {
 
         private void BuildTemplate() {
             _template = new GameObject("BrokenNodesTemplate").AddComponent<UIPanel>();
+            _template.transform.SetParent(_defaultGameObject.transform, true);
             _template.width = 400;
             _template.height = 50;
             UILabel label = _template.AddUIComponent<UILabel>();

--- a/BrokenNodeDetector/UI/Tools/BrokenPathTool/BrokenPaths.cs
+++ b/BrokenNodeDetector/UI/Tools/BrokenPathTool/BrokenPaths.cs
@@ -161,6 +161,7 @@ namespace BrokenNodeDetector.UI.Tools.BrokenPathTool {
 
         private void BuildResultTemplate() {
             _template = new GameObject("BrokenPathsTemplate").AddComponent<UIPanel>();
+            _template.transform.SetParent(_defaultGameObject.transform, true);
             _template.width = 400;
             _template.height = 50;
             UILabel label = _template.AddUIComponent<UILabel>();
@@ -190,6 +191,7 @@ namespace BrokenNodeDetector.UI.Tools.BrokenPathTool {
 
         private void BuildPrepareTemplate() {
             _templatePrepare = new GameObject("BrokenPathsPrepareTemplate").AddComponent<UIPanel>();
+            _templatePrepare.transform.SetParent(_defaultGameObject.transform, true);
             _templatePrepare.width = 400;
             _templatePrepare.height = 50;
             UILabel label = _templatePrepare.AddUIComponent<UILabel>();
@@ -203,6 +205,7 @@ namespace BrokenNodeDetector.UI.Tools.BrokenPathTool {
 
         private void BuildRowTemplate() {
             UIPanel resultRow = new GameObject("BrokenPathsRowTemplate").AddComponent<UIPanel>();
+            resultRow.gameObject.transform.SetParent(_defaultGameObject.transform, true);
             resultRow.name = RESULT_ROW;
             resultRow.width = 400;
             resultRow.height = 40;

--- a/BrokenNodeDetector/UI/Tools/BrokenPropsTool/BrokenProps.cs
+++ b/BrokenNodeDetector/UI/Tools/BrokenPropsTool/BrokenProps.cs
@@ -1,3 +1,4 @@
+#if BROKEN_PROPS_SCANNER
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
@@ -146,3 +147,4 @@ namespace BrokenNodeDetector.UI.Tools.BrokenPropsTool {
         }
     }
 }
+#endif

--- a/BrokenNodeDetector/UI/Tools/BrokenPropsTool/BrokenPropsEML.cs
+++ b/BrokenNodeDetector/UI/Tools/BrokenPropsTool/BrokenPropsEML.cs
@@ -1,3 +1,4 @@
+#if BROKEN_PROPS_SCANNER
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -170,3 +171,4 @@ namespace BrokenNodeDetector.UI.Tools.BrokenPropsTool {
         }
     }
 }
+#endif

--- a/BrokenNodeDetector/UI/Tools/DetectorFactory.cs
+++ b/BrokenNodeDetector/UI/Tools/DetectorFactory.cs
@@ -46,6 +46,7 @@ namespace BrokenNodeDetector.UI.Tools {
                 }
             }
             _detectors.Clear();
+            Detector.DisposeDefaultGameObject();
         }
     }
 }

--- a/BrokenNodeDetector/UI/Tools/DetectorFactory.cs
+++ b/BrokenNodeDetector/UI/Tools/DetectorFactory.cs
@@ -19,7 +19,8 @@ namespace BrokenNodeDetector.UI.Tools {
     public class DetectorFactory : IDisposable {
         private List<Detector> _detectors;
         
-        public DetectorFactory() {
+        public DetectorFactory() {           
+            PropAPI.Initialize();
             _detectors = new List<Detector> {
                 new BrokenNodes(),
                 new GhostNodes(),

--- a/BrokenNodeDetector/UI/Tools/DetectorFactory.cs
+++ b/BrokenNodeDetector/UI/Tools/DetectorFactory.cs
@@ -3,13 +3,17 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using BrokenNodeDetector.UI.Tools.BrokenNodesTool;
 using BrokenNodeDetector.UI.Tools.BrokenPathTool;
+#if BROKEN_PROPS_SCANNER
 using BrokenNodeDetector.UI.Tools.BrokenPropsTool;
+#endif
 using BrokenNodeDetector.UI.Tools.DisconnectedBuildingsTool;
 using BrokenNodeDetector.UI.Tools.DisconnectedPublicTransportStopsTool;
 using BrokenNodeDetector.UI.Tools.StuckCimsTool;
 using BrokenNodeDetector.UI.Tools.GhostNodesTool;
 using BrokenNodeDetector.UI.Tools.ShortSegmentsTool;
+#if BROKEN_PROPS_SCANNER
 using EManagersLib.API;
+#endif
 #if SEGMENT_UPDATER
 using BrokenNodeDetector.UI.Tools.SegmentUpdateTool;
 #endif
@@ -20,7 +24,9 @@ namespace BrokenNodeDetector.UI.Tools {
         private List<Detector> _detectors;
         
         public DetectorFactory() {           
+#if BROKEN_PROPS_SCANNER
             PropAPI.Initialize();
+#endif
             _detectors = new List<Detector> {
                 new BrokenNodes(),
                 new GhostNodes(),
@@ -30,7 +36,9 @@ namespace BrokenNodeDetector.UI.Tools {
 #if SEGMENT_UPDATER
                 // new SegmentUpdateRequest(),
 #endif
+#if BROKEN_PROPS_SCANNER
                 (PropAPI.m_isEMLInstalled ? (Detector)new BrokenPropsEML() : new BrokenProps()),
+#endif
                 new StuckCims(),
                 new BrokenPaths(),
             };

--- a/BrokenNodeDetector/UI/Tools/DisconnectedBuildingsTool/DisconnectedBuildings.cs
+++ b/BrokenNodeDetector/UI/Tools/DisconnectedBuildingsTool/DisconnectedBuildings.cs
@@ -130,6 +130,7 @@ namespace BrokenNodeDetector.UI.Tools.DisconnectedBuildingsTool {
 
         private void BuildTemplate() {
             _template = new GameObject("DisconnectedBuildingTemplate").AddComponent<UIPanel>();
+            _template.transform.SetParent(_defaultGameObject.transform, true);
             _template.width = 400;
             _template.height = 50;
             UILabel label = _template.AddUIComponent<UILabel>();

--- a/BrokenNodeDetector/UI/Tools/DisconnectedBuildingsTool/DisconnectedBuildings.cs
+++ b/BrokenNodeDetector/UI/Tools/DisconnectedBuildingsTool/DisconnectedBuildings.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using ColossalFramework.UI;
@@ -29,13 +28,19 @@ namespace BrokenNodeDetector.UI.Tools.DisconnectedBuildingsTool {
             ResetState();
 
             _progress = 0f;
-            AsyncTask<float> asyncTask = SimulationManager.instance.AddAction(ProcessInternal());
+            AsyncTask<float> asyncTask = SimulationManager.instance.AddAction(CheckRoadAccess());
             while (!asyncTask.completed) {
+                yield return _progress;
+            }
+            
+            _progress = 0f;
+            AsyncTask<float> asyncTask2 = SimulationManager.instance.AddAction(CollectDisconnectedBuildings());
+            while (!asyncTask2.completed) {
                 yield return _progress;
             }
 
             yield return 1.0f;
-            IsProcessing = true;
+            IsProcessing = false;
         }
 
         public override void InitResultsView(UIComponent component) {
@@ -63,65 +68,75 @@ namespace BrokenNodeDetector.UI.Tools.DisconnectedBuildingsTool {
             templateInstance.Find<UIButton>("MoveNext").eventClick += MoveNextBuildingButtonClick;
         }
 
-        private IEnumerator<float> ProcessInternal() {
+        private IEnumerator<float> CheckRoadAccess() {
             BuildingManager bm = BuildingManager.instance;
             float searchStep = 1.0f / bm.m_buildings.m_size;
+            
+            ProgressMessage = $"Processing...0% Pass 1/2";
+            Building[] mBuffer = bm.m_buildings.m_buffer;
+            for (int i = 1; i < mBuffer.Length; i++) {
+
+                if ((mBuffer[i].m_flags & (Building.Flags.Created | Building.Flags.Deleted)) == Building.Flags.Created &&
+                    mBuffer[i].Info
+                    ) {
+                    mBuffer[i].Info.m_buildingAI.CheckRoadAccess((ushort)i, ref mBuffer[i]);
+                }
+
+                float searchProgress = searchStep * i;
+                if (i % 64 == 0) {
+                    ProgressMessage = $"Processing...{searchProgress * 100:F0}% Pass 1/2";
+                    Thread.Sleep(1);
+                    _progress = searchProgress;
+                }
+            }
+            ProgressMessage = $"Processing...100% Pass 1/2";
+            
+            yield return 1.0f;
+        }
+
+        private IEnumerator<float> CollectDisconnectedBuildings() {
             StringBuilder sb = new StringBuilder();
             sb.AppendLine("[BND] Scanning for disconnected buildings");
             sb.AppendLine("[BND] ");
             sb.AppendLine("[BND] =( Building ID )===( Location )=");
             sb.AppendLine();
-            ProgressMessage = $"Processing...0%";
+            BuildingManager bm = BuildingManager.instance;
             Building[] mBuffer = bm.m_buildings.m_buffer;
+            float searchStep = 1.0f / bm.m_buildings.m_size;
+            
+            ProgressMessage = "Processing...0% Pass 2/2";
+            _progress = 0f;
+            
             int counter = 0;
-            MethodInfo findRoadAccess = typeof(PlayerBuildingAI).GetMethod("FindRoadAccess", BindingFlags.Instance | BindingFlags.NonPublic);
-            for (int i = 0; i < mBuffer.Length; i++) {
-                Building building = mBuffer[i];
+            for (int i = 1; i < mBuffer.Length; i++) {
 
-                if ((building.m_flags & Building.Flags.Created) != 0 && building.Info) {
-                    if (building.Info.m_buildingAI is PlayerBuildingAI) {
+                if ((mBuffer[i].m_flags & (Building.Flags.Created | Building.Flags.Deleted)) == Building.Flags.Created &&
+                    mBuffer[i].Info
+                    ) {
+                    bool notConnected = ((mBuffer[i].m_flags & Building.Flags.RoadAccessFailed) != Building.Flags.None &&
+                                         ((mBuffer[i].m_problems.m_Problems1 & (Notification.Problem1.RoadNotConnected | Notification.Problem1.PathNotConnected)) != Notification.Problem1.None ||
+                                          (mBuffer[i].m_problems.m_Problems2 & (Notification.Problem2.NotInPedestrianZone | Notification.Problem2.CannotBeReached)) != Notification.Problem2.None));
+
+                    if (notConnected) {
                         counter++;
-                        PlayerBuildingAI buildingAI = building.Info.m_buildingAI as PlayerBuildingAI;
-                        bool connected = true;
-                        if ((building.m_flags & Building.Flags.Collapsed) == Building.Flags.None && buildingAI.RequireRoadAccess()) {
-                            Vector3 position = buildingAI.m_info.m_zoningMode != BuildingInfo.ZoningMode.CornerLeft
-                                ? (buildingAI.m_info.m_zoningMode != BuildingInfo.ZoningMode.CornerRight
-                                    ? building.CalculateSidewalkPosition(0.0f, 4f)
-                                    : building.CalculateSidewalkPosition(building.Width * -4f, 4f))
-                                : building.CalculateSidewalkPosition(building.Width * 4f, 4f);
-                            object[] args = { (ushort)i, building, position, null, true, false };
-                            if (!(bool)findRoadAccess.Invoke(buildingAI, args))
-                                connected = false;
-                        }
-
-                        if (!connected) {
-                            _disconnectedBuildings.Add((ushort)i, building.m_position);
-                            sb.AppendLine("==(" + i + ")===(" + building.m_position + ")=");
-                            sb.Append("building ")
-                                .Append(" " + (building.Info ? building.Info.m_class.name : "") + " ")
-                                .Append(building.m_flags.ToString())
-                                .Append(" [name: ").Append(building.Info.name).Append("]");
-                            sb.AppendLine("---------------------------------------");
-                        }
-                    } else if ((building.m_flags & Building.Flags.RoadAccessFailed) != 0 || (building.m_problems.m_Problems1 & Notification.Problem1.RoadNotConnected) != 0) {
-                        _disconnectedBuildings.Add((ushort)i, building.m_position);
-                        sb.AppendLine("==(" + i + ")===(" + building.m_position + ")=");
-                        sb.Append("building ")
-                            .Append(" " + (building.Info ? building.Info.m_class.name : "") + " ")
-                            .Append(building.m_flags.ToString())
-                            .Append(" [name: ").Append(building.Info.name).Append("]");
+                        _disconnectedBuildings.Add((ushort)i, mBuffer[i].m_position);
+                        sb.AppendLine("==(" + i + ")===" + mBuffer[i].m_position + "==");
+                        sb.Append("Building [ItemClass: ")
+                            .Append((mBuffer[i].Info ? mBuffer[i].Info.m_class.name : "") + "] [Flags: ")
+                            .Append(mBuffer[i].m_flags.ToString()).Append("] [Problems: ").Append(mBuffer[i].m_problems.ToString())
+                            .Append("] [Name: ").Append(mBuffer[i].Info.name).Append("]");
                         sb.AppendLine("---------------------------------------");
                     }
                 }
 
                 float searchProgress = searchStep * i;
-                if (i % 32 == 0) {
-                    ProgressMessage = $"Processing...{searchProgress * 100:F0}%";
+                if (i % 128 == 0) {
+                    ProgressMessage = $"Processing...{searchProgress * 100:F0}% Pass 2/2";
                     Thread.Sleep(1);
                     _progress = searchProgress;
                 }
             }
-            ProgressMessage = $"Processing...100%";
+            ProgressMessage = $"Processing...100% Pass 2/2";
 
             Debug.Log("[BND] Disconnected building instances count: " + counter);
             Debug.Log("[BND] Scan report\n" + sb + "\n\n=======================================================");
@@ -151,20 +166,22 @@ namespace BrokenNodeDetector.UI.Tools.DisconnectedBuildingsTool {
             UIPanel buildingPanel = _template.AddUIComponent<UIPanel>();
             buildingPanel.width = 400;
             buildingPanel.height = 40;
-            buildingPanel.relativePosition = new Vector2(10, 45);
+            buildingPanel.relativePosition = new Vector2(15, 45);
             buildingPanel.name = "BuildingPanel";
             
             UILabel buildingId = buildingPanel.AddUIComponent<UILabel>();
+            buildingId.processMarkup = true;
             buildingId.prefix = "Building ID: ";
-            buildingId.relativePosition = new Vector2(20, 10);
+            buildingId.relativePosition = new Vector2(0, 10);
             buildingId.name = "BuildingID";
-            buildingId.textScale = 0.9f;
+            buildingId.textScale = 0.8f;
             
             UILabel buildingPos = buildingPanel.AddUIComponent<UILabel>();
+            buildingPos.processMarkup = true;
             buildingPos.prefix = "Position: ";
-            buildingPos.relativePosition = new Vector2(200, 10);
+            buildingPos.relativePosition = new Vector2(150, 10);
             buildingPos.name = "BuildingPosition";
-            buildingPos.textScale = 0.9f;
+            buildingPos.textScale = 0.8f;
             
             buildingPanel.Hide();
         }
@@ -216,6 +233,7 @@ namespace BrokenNodeDetector.UI.Tools.DisconnectedBuildingsTool {
             if (_disconnectedBuildings.Count == 0) {
                 ResetState();
                 label.text = "Great! Nothing found :-)";
+                label.textColor = new Color(0f, 0.81f, 0.05f);
                 label.parent.height = 50;
                 label.relativePosition = Vector3.zero;
                 label.color = Color.white;
@@ -227,16 +245,16 @@ namespace BrokenNodeDetector.UI.Tools.DisconnectedBuildingsTool {
             UILabel buildingId = buildingPanel.Find<UILabel>("BuildingID");
             UILabel buildingPos = buildingPanel.Find<UILabel>("BuildingPosition");
             if (_currentBuilding != 0 && _disconnectedBuildings.TryGetValue(_currentBuilding, out Vector3 position)) {
-                buildingId.text = _currentBuilding.ToString();
-                buildingPos.text = position.ToString();
+                buildingId.text = $"<color #FFF000>{_currentBuilding.ToString()}</color>";
+                buildingPos.text = $"<color #FFF000>{position.ToString()}</color>";
             } else {
                 buildingId.text = " ";
                 buildingPos.text = " ";
             }
 
-            label.relativePosition = new Vector3(20, 0);
-            label.text = $"{_disconnectedBuildings.Count} possibly disconnected building(s)";
-            label.color = Color.yellow;
+            label.relativePosition = new Vector3(15, 0);
+            label.processMarkup = true;
+            label.text = $"<color #FFAA00>{_disconnectedBuildings.Count}</color> possibly disconnected building(s)";
         }
 
         private void UpdateBuildingButtons(UIComponent moveNextButton) {

--- a/BrokenNodeDetector/UI/Tools/DisconnectedPublicTransportStopsTool/DisconnectedPublicTransportStops.cs
+++ b/BrokenNodeDetector/UI/Tools/DisconnectedPublicTransportStopsTool/DisconnectedPublicTransportStops.cs
@@ -173,6 +173,7 @@ namespace BrokenNodeDetector.UI.Tools.DisconnectedPublicTransportStopsTool {
 
         private void BuildTemplate() {
             _template = new GameObject("DisconnectedPTStopTemplate").AddComponent<UIPanel>();
+            _template.transform.SetParent(_defaultGameObject.transform, true);
             _template.width = 400;
             _template.height = 50;
             UILabel label = _template.AddUIComponent<UILabel>();

--- a/BrokenNodeDetector/UI/Tools/IDetector.cs
+++ b/BrokenNodeDetector/UI/Tools/IDetector.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 
 namespace BrokenNodeDetector.UI.Tools {
     public abstract class Detector : IDetector, IDisposable {
+        internal static GameObject _defaultGameObject = new GameObject("BND_Detectors");
         protected static UIComponent _defaultTemplate;
         protected UIComponent _template;
         protected UIComponent _templatePrepare;
@@ -52,6 +53,8 @@ namespace BrokenNodeDetector.UI.Tools {
             if (_defaultTemplate) return;
 
             UILabel label = new GameObject("Result Default UI").AddComponent<UILabel>();
+            label.gameObject.transform.SetParent(_defaultGameObject.transform, true);
+            label.gameObject.transform.SetParent(_defaultGameObject.transform, true);
             label.autoSize = true;
             label.padding = new RectOffset(10, 10, 15, 15);
             _defaultTemplate = label;
@@ -71,6 +74,13 @@ namespace BrokenNodeDetector.UI.Tools {
             if (_defaultTemplate) {
                 UnityEngine.Object.Destroy(_defaultTemplate.gameObject);
                 _defaultTemplate = null;
+            }
+        }
+
+        internal static void DisposeDefaultGameObject() {
+            if (_defaultGameObject) {
+                UnityEngine.Object.Destroy(_defaultGameObject);
+                _defaultGameObject = null;
             }
         }
     }

--- a/BrokenNodeDetector/UI/Tools/ShortSegmentsTool/ShortSegments.cs
+++ b/BrokenNodeDetector/UI/Tools/ShortSegmentsTool/ShortSegments.cs
@@ -130,6 +130,7 @@ namespace BrokenNodeDetector.UI.Tools.ShortSegmentsTool {
 
         private void BuildTemplate() {
             _template = new GameObject("ShortSegmentsTemplate").AddComponent<UIPanel>();
+            _template.transform.SetParent(_defaultGameObject.transform, true);
             _template.width = 400;
             _template.height = 50;
             UILabel label = _template.AddUIComponent<UILabel>();

--- a/BrokenNodeDetector/UI/Tools/StuckCimsTool/StuckCims.cs
+++ b/BrokenNodeDetector/UI/Tools/StuckCimsTool/StuckCims.cs
@@ -116,6 +116,7 @@ namespace BrokenNodeDetector.UI.Tools.StuckCimsTool {
 
         private void BuildResultTemplate() {
             _template = new GameObject("StuckCimsTemplate").AddComponent<UIPanel>();
+            _template.transform.SetParent(_defaultGameObject.transform, true);
             _template.width = 400;
             _template.height = 50;
             UILabel label = _template.AddUIComponent<UILabel>();
@@ -145,6 +146,7 @@ namespace BrokenNodeDetector.UI.Tools.StuckCimsTool {
 
         private void BuildPrepareTemplate() {
             _templatePrepare = new GameObject("StuckCimsPrepareTemplate").AddComponent<UIPanel>();
+            _templatePrepare.gameObject.transform.SetParent(_defaultGameObject.transform, true);
             _templatePrepare.width = 400;
             _templatePrepare.height = 50;
             UILabel label = _templatePrepare.AddUIComponent<UILabel>();
@@ -158,6 +160,7 @@ namespace BrokenNodeDetector.UI.Tools.StuckCimsTool {
 
         private void BuildRowTemplate() {
             UIPanel resultRow = new GameObject("StuckCimsRowTemplate").AddComponent<UIPanel>();
+            resultRow.gameObject.transform.SetParent(_defaultGameObject.transform, true);
             resultRow.name = RESULT_ROW;
             resultRow.width = 400;
             resultRow.height = 40;

--- a/BrokenNodeDetector/UI/Tools/Utils/EMLUtisl.cs
+++ b/BrokenNodeDetector/UI/Tools/Utils/EMLUtisl.cs
@@ -3,6 +3,7 @@ using ColossalFramework;
 using ColossalFramework.Plugins;
 
 namespace BrokenNodeDetector.UI.Tools.Utils {
+#if BROKEN_PROPS_SCANNER
     public class EmlUtils {
         internal static bool IsEmlInstalled() {
             foreach (PluginManager.PluginInfo pluginInfo in Singleton<PluginManager>.instance.GetPluginsInfo()) {
@@ -20,4 +21,5 @@ namespace BrokenNodeDetector.UI.Tools.Utils {
             return false;
         }
     }
+#endif
 }

--- a/BrokenNodeDetector/UI/Tools/Utils/EMLUtisl.cs
+++ b/BrokenNodeDetector/UI/Tools/Utils/EMLUtisl.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using ColossalFramework;
+using ColossalFramework.Plugins;
+
+namespace BrokenNodeDetector.UI.Tools.Utils {
+    public class EmlUtils {
+        internal static bool IsEmlInstalled() {
+            foreach (PluginManager.PluginInfo pluginInfo in Singleton<PluginManager>.instance.GetPluginsInfo()) {
+                try {
+                    foreach (Assembly assembly in pluginInfo.GetAssemblies()) {
+                        bool flag = assembly.GetName().Name.ToLower().Equals("emanagerslib");
+                        if (flag) {
+                            return pluginInfo.isEnabled;
+                        }
+                    }
+                } catch {
+                    // ignore
+                }
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
_Fixed:_
- Removed **EML** integration and **disabled** experimental _"Broken Props Detector"_
- incorrectly canceled preparation step (broken path detector) when user clicked ◀️ before selecting building to start searching for paths which resulted in completely unusable detector next time.
- eliminated most of garbage generation in animated highlight color manager
- improved search for disconnected buildings and also the Building selection tool for _Broken Path Detector_

_Updated:_
- minor template reorganizations so they are now located under single GameObject entry (in ModTools) instead of being separate entries each 
